### PR TITLE
Adding --clear option for "git-together with"

### DIFF
--- a/bats/integration.bats
+++ b/bats/integration.bats
@@ -111,7 +111,7 @@ AUTHORS
   [[ "$output" =~ "$expected" ]]
 
   run git config git-together.active
-  [ "$output" = "" ]
+  [  "$output" = "jh" ]
 }
 
 @test "no signoff" {
@@ -170,6 +170,13 @@ AUTHORS
 
   run git-together with
   [ "$status" -eq 0 ]
+}
+
+@test "clear" {
+  git-together with --clear
+
+  run git config git-together.active
+  [ "$output" = "" ]
 }
 
 setup() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,9 +21,8 @@ fn main() {
                          option_env!("CARGO_PKG_VERSION")
                              .unwrap_or("unknown version"));
 
-                let mut gt = GitTogether::new()?;
+                let gt = GitTogether::new()?;
 
-                let _ = gt.set_active(&[]);
                 let authors = gt.all_authors()?;
                 let mut sorted: Vec<_> = authors.iter().collect();
                 sorted.sort_by(|a, b| a.0.cmp(b.0));
@@ -31,6 +30,11 @@ fn main() {
                 for (initials, author) in sorted {
                     println!("{}: {}", initials, author);
                 }
+            }
+            ["with", ref inits..] if inits.contains(&"--clear") => {
+                let mut gt = GitTogether::new()?;
+
+                let _ = gt.set_active(&[]);
             }
             ["with", ref inits..] => {
                 let mut gt = GitTogether::new()?;


### PR DESCRIPTION
Implements feature for #5
```--clear``` will remove the active pair. This also prevents ```with```
without any additional arguments from removing the current active pair.