### PR TITLE
Skip over global args when looking for command

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,6 +54,7 @@ pub fn run() -> Result<i32> {
                 skip_next = true;
                 false
             },
+            &&"--version" | &&"--help" => true,
             v @ _ if v.starts_with("-") => false,
             _ => true,
         }


### PR DESCRIPTION
This (a) supports using global args with git-together before the command, and (b) enables it to work with IntelliJ IDEA.